### PR TITLE
added distributionSha256Sum to gradle/wrapper/gradle-wrapper.properties

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,3 +4,4 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionSha256Sum=9af7345c199f1731c187c96d3fe3d31f5405192a42046bafa71d846c3d9adacb


### PR DESCRIPTION
Added distributionSha256Sum to gradle/wrapper/gradle-wrapper.properties file according to https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:verification 

```bash
$ wget https://services.gradle.org/distributions/gradle-4.6-all.zip
$ sha256sum gradle-4.6-all.zip
9af7345c199f1731c187c96d3fe3d31f5405192a42046bafa71d846c3d9adacb  gradle-4.6-all.zip
```

Also see report of f-droid scanner:
https://gitlab.com/fdroid/rfp/issues/951#note_157744251 